### PR TITLE
Change file permissions of the credentials file

### DIFF
--- a/src/api/services/auth.ts
+++ b/src/api/services/auth.ts
@@ -39,6 +39,8 @@ export function saveCredentials(credentials: ICredentials): void {
     `${os.homedir()}/${STACKPATH_CREDENTIALSFILE_PATH}`,
     JSON.stringify(credentials)
   );
+
+  fs.chmodSync(`${os.homedir()}/${STACKPATH_CREDENTIALSFILE_PATH}`, "0600");
 }
 
 /**


### PR DESCRIPTION
Changes proposed in this pull request:

* This pull request changes the permissions for the credentials file. It's now given chmod `0600`, to prevent unauthorised leaking of its contents.
