### PR TITLE
Remove all response.clone().json() calls …

### DIFF
--- a/src/api/services/auth.ts
+++ b/src/api/services/auth.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as os from "os";
-
+import cliUx from "cli-ux";
 import { ICredentials } from "../interfaces";
 import {
   STACKPATH_CREDENTIALSFILE_PATH,
@@ -77,6 +77,14 @@ export async function getAccessToken(): Promise<string> {
   });
 
   const body = await response.json();
+
+  // Exit if cannot retrieve an access token
+  if (!response.ok) {
+    cliUx.log(
+      `An error occurred trying to retrieve an access token: ${body.message}`
+    );
+    process.exit(1);
+  }
 
   credentials.access_token = body.access_token;
   credentials.access_token_expiry =

--- a/src/api/services/deploy.ts
+++ b/src/api/services/deploy.ts
@@ -1,12 +1,11 @@
 import * as fs from "fs";
 import cliUx from "cli-ux";
-import { Response as NodeFetchResponse } from "node-fetch";
-
 import { IConfiguration, IConfigurationScript } from "../interfaces";
 import { STACKPATH_CONFIGFILE_PATH } from "../constants";
 import * as Validation from "./validation";
 import * as Http from "./http";
 import * as Log from "./log";
+import { continueOnErrorPrompt } from "./prompt";
 
 /*
  * Class performing all Deploy tasks.
@@ -52,13 +51,15 @@ export class Deploy {
     cliUx.action.start("Deploying scripts...");
 
     try {
-      await this.configuration.scripts.reduce(
-        async (previousPromise, nextScript, index) => {
-          await previousPromise;
-          return this.handleScriptUpload(nextScript, index);
-        },
-        Promise.resolve()
-      );
+      for (let i = 0; i < this.configuration.scripts.length; i++) {
+        try {
+          const script = this.configuration.scripts[i];
+          await this.handleScriptUpload(script, i);
+        } catch (e) {
+          // Check if user wants to try to update subsequent scripts after an error
+          await continueOnErrorPrompt(e);
+        }
+      }
 
       Log.logVerbose(
         `Saving new configuration file to ${STACKPATH_CONFIGFILE_PATH}`
@@ -97,27 +98,26 @@ export class Deploy {
       code: scriptContentBase64
     };
 
-    const siteId =
-      script.hasOwnProperty("site_id") && script.site_id !== ""
-        ? script.site_id
-        : this.configuration.site_id;
-    if (script.hasOwnProperty("id") && script.id !== "") {
+    const siteId = script.site_id || this.configuration.site_id;
+    const stackId = this.configuration.stack_id;
+    const scriptId = script.id;
+
+    if (scriptId) {
       Log.logVerbose(
-        `Updating script ${script.name} with id ${script.id} to site ${siteId}.`
+        `Updating script ${script.name} with id ${scriptId} to site ${siteId}.`
       );
 
       const response = await Http.request(
         "PATCH",
-        `/cdn/v1/stacks/${
-          this.configuration.stack_id
-        }/sites/${siteId}/scripts/${script.id}`,
-        body,
-        false
+        `/cdn/v1/stacks/${stackId}/sites/${siteId}/scripts/${script.id}`,
+        body
       );
 
-      const json = await response.clone().json();
+      const respBody: ScriptResponse = await response.json();
 
-      if (response.status === 404 && json.code === 5) {
+      if (response.ok && respBody.script) {
+        cliUx.log(`Successfully updated script ${script.name}`);
+      } else if (response.status === 404 && respBody.code === 5) {
         // code 5 means Site script does not exist.
         Log.logVerbose(`Script ${script.name} does not exist (anymore).`);
         let recreateScript = this.force;
@@ -130,38 +130,42 @@ export class Deploy {
           );
         }
         if (recreateScript) {
-          Log.logVerbose(`Will recreate script ${script.name}.`);
-          script.id = "";
-        } else {
-          if (await Http.handleResponseError(response, false)) {
-            await this.updateScriptWithResponse(script, response, index);
-          } else {
-            throw new Error("Operation canceled.");
-          }
-        }
-      } else {
-        if (await Http.handleResponseError(response, false)) {
-          await this.updateScriptWithResponse(script, response, index);
+          await this.createScript({ script, siteId, body, index });
         } else {
           throw new Error("Operation canceled.");
         }
+      } else {
+        throw new Error(`Update Script Request failed ${respBody.message}`);
       }
+    } else {
+      await this.createScript({ script, siteId, body, index });
     }
+  }
 
-    if (!script.hasOwnProperty("id") || script.id === "") {
-      Log.logVerbose(`Creating script ${script.name} for site ${siteId}.`);
+  private async createScript(options: {
+    script: IConfigurationScript;
+    siteId: string;
+    body: object;
+    index: number;
+  }) {
+    const { script, siteId, body, index } = options;
+    Log.logVerbose(`Creating script ${script.name} for site ${siteId}.`);
 
-      const response = await Http.request(
-        "POST",
-        `/cdn/v1/stacks/${this.configuration.stack_id}/sites/${siteId}/scripts`,
-        body
-      );
-      Log.logVerbose(
-        `HTTP Response for script ${script.name}: ${response.status}`
-      );
+    const response = await Http.request(
+      "POST",
+      `/cdn/v1/stacks/${this.configuration.stack_id}/sites/${siteId}/scripts`,
+      body
+    );
+    Log.logVerbose(
+      `HTTP Response for script ${script.name}: ${response.status}`
+    );
 
-      await this.updateScriptWithResponse(script, response, index);
+    const respBody: ScriptResponse = await response.json();
+
+    if (!response.ok || !respBody.script) {
+      throw new Error(`Failed to create script (${respBody.message})`);
     }
+    await this.updateScriptIdInConfig(script, respBody.script.id, index);
   }
 
   /**
@@ -170,19 +174,20 @@ export class Deploy {
    * @param {Response} response - The response that contains the (new) id.
    * @param {number} index - The index of the script.
    */
-  private async updateScriptWithResponse(
+  private async updateScriptIdInConfig(
     script: IConfigurationScript,
-    response: NodeFetchResponse,
+    scriptId: string,
     index: number
   ) {
-    if (response !== undefined) {
-      const json = await response.clone().json();
-      if (json) {
-        Log.logVerbose(
-          `Saving id for created script ${script.name} to ${json.script.id}`
-        );
-        this.configuration.scripts[index].id = json.script.id;
-      }
-    }
+    Log.logVerbose(
+      `Saving id for created script ${script.name} to ${scriptId}`
+    );
+    this.configuration.scripts[index].id = scriptId;
   }
+}
+
+interface ScriptResponse {
+  script?: { id: string };
+  code?: number;
+  message?: string;
 }

--- a/src/api/services/http.ts
+++ b/src/api/services/http.ts
@@ -15,8 +15,7 @@ import * as Log from "./log";
 export async function request(
   method: string,
   resource: string,
-  body?: any,
-  throwErrors: boolean = true
+  body?: any
 ): Promise<NodeFetchResponse> {
   try {
     const response = await nodeFetch(`${STACKPATH_HOST}${resource}`, {
@@ -28,9 +27,9 @@ export async function request(
       body: body ? JSON.stringify(body) : undefined
     });
 
-    if (throwErrors) {
-      await handleResponseError(response, throwErrors);
-    }
+    Log.logVerbose(
+      `HTTP Request ${method} ${STACKPATH_HOST}${resource} ${response.status}`
+    );
 
     return response;
   } catch (error) {
@@ -38,27 +37,4 @@ export async function request(
       `An error occurred when connecting to StackPath host ${STACKPATH_HOST}.`
     );
   }
-}
-
-/**
- * Handles HTTP response and throws CLI error if needed.
- * @param response {Promise<Response>} - The response from node-fetch.
- * @returns {Promise<boolean>}
- */
-export async function handleResponseError(
-  response: NodeFetchResponse,
-  throwErrors: boolean = true
-): Promise<boolean> {
-  if (response.status !== 200) {
-    const error = await response.clone().json();
-    const errorMessage = `${error.message}. Original url ${response.url}`;
-    await Log.logError(errorMessage);
-    if (throwErrors) {
-      throw new Error(errorMessage);
-    }
-
-    return false;
-  }
-
-  return true;
 }

--- a/src/api/services/log.ts
+++ b/src/api/services/log.ts
@@ -13,24 +13,6 @@ export function logVerbose(log: string) {
   }
 }
 
-/**
- * Logs error to output and prompts user to continue or not.
- * @param {string} log - The string that needs to be logged to the output.
- */
-export async function logError(log: string) {
-  cliUx.log(log);
-  if (!!!process.env.STACKPATH_FORCE) {
-    const continueProcess = await cliUx.prompt(
-      `An error has occurred (${log}). Continue? y/n`
-    );
-
-    if (continueProcess !== "y") {
-      cliUx.log("Exiting...");
-      process.exit(1);
-    }
-  }
-}
-
 export enum LogLevel {
   VERBOSE = "verbose",
   INFO = "info"

--- a/src/api/services/prompt.ts
+++ b/src/api/services/prompt.ts
@@ -1,0 +1,18 @@
+import cliUx from "cli-ux";
+
+/**
+ * Prompts the user if they want to continue or not after an error.
+ * @param {string} log - The string that needs to be logged to the output.
+ */
+export async function continueOnErrorPrompt(e: any) {
+  if (!process.env.STACKPATH_FORCE) {
+    const continueProcess = await cliUx.prompt(
+      `An error has occurred (${e}). Continue? y/n`
+    );
+
+    if (continueProcess !== "y") {
+      cliUx.log("Exiting...");
+      process.exit(1);
+    }
+  }
+}

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -66,7 +66,7 @@ export default class Deploy extends Command {
     const deploy = new DeployService();
     try {
       await deploy.deployScripts({
-        force: !!process.env.STACKPATH_FORCE
+        force: Boolean(process.env.STACKPATH_FORCE)
       });
     } catch (e) {
       cliUx.log(e.message);

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,7 @@
 {
   "extends": ["tslint:recommended", "tslint-config-prettier"],
   "rules": {
+    "interface-name": false,
     "object-literal-sort-keys": false,
     "ordered-imports": false
   }


### PR DESCRIPTION
When script bodies were bigger than 1 MB, the CLI would silently crash because of https://github.com/bitinn/node-fetch/issues/396

Also refactor some of the http error handling. As it was, it would prompt the user if they wanted to continue or kill the process on any http request failure, which is a bit surprising. Instead, I just automatically fail out if auth call fails (since you can't do anything without auth), and in the case of script create/update fail, I prompt the user if they want to continue onto the next script or exit out.