### PR TITLE
Allow overriding stack_id per script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-EdgeEngine CLI
-==============
+# EdgeEngine CLI
 
 EdgeEngine is StackPath's serverless platform. It allows you to add custom logic to your applications or even build entire applications on the edge. With a simple deploy your scripts are deployed to StackPath's vast network containing over 45 POP's. This CLI makes deploying as easy as running a single command, no matter the amount of scripts you have.
 
@@ -8,34 +7,42 @@ EdgeEngine is StackPath's serverless platform. It allows you to add custom logic
 [![License](https://img.shields.io/npm/l/@stackpath/edgeengine-cli.svg?style=flat)](https://github.com/stackpath/edgeengine-cli/blob/master/LICENSE.md)
 
 # Introduction
+
 This CLI makes deploying to EdgeEngine as easy as running a single command. It's easy to use, but allows for a variety of use-cases. You can run the CLI locally to make deploying a whole lot quicker, run it in a CI/CD pipeline to automate the deployments, or implement it in any way you can think of.
 
 **How to get started?**
+
 1. [Install the CLI](#installing-the-cli)
 2. [Save your credentials](#setting-authentication-details)
 3. [Set up the configuration file](#configure-project)
 4. [Deploy](#deploying-with-the-cli)
 
 ## Installing the CLI
+
 Depending on your platform and your own preferences there are a couple of ways to get the CLI. The preferred way is probably to install it through NPM.
 
 ### Installing through NPM
+
 `npm install -g @stackpath/edgeengine-cli` to install globally
 
 ### Downloading the installer
-* For MacOS (.pkg) -> [Download](https://storage.googleapis.com/cli-dl/edgeengine-v1.0.0.pkg)
-* For Windows (.exe) -> Download
-* For Ubuntu (.deb) -> Download
+
+- For MacOS (.pkg) -> [Download](https://storage.googleapis.com/cli-dl/edgeengine-v1.0.0.pkg)
+- For Windows (.exe) -> Download
+- For Ubuntu (.deb) -> Download
 
 ## Setting authentication details
+
 The CLI saves your authentication data in a file in your home directory (`~/.stackpath/credentials`). Once you have set this up, the CLI will continue to read the credentials from the file, meaning that you don't have to provide your credentials over and over again.
 
 In order to authenticate yourself, you need a client ID and a client secret. You can find them in [the StackPath client portal](https://control.stackpath.com/api-management).
 
 ### Authenticating in an interactive environment (e.g. on your local machine)
-> 👉 To authenticate in an interactive environment you can simply run `edgeengine auth`. The CLI will prompt you for required details. 
+
+> 👉 To authenticate in an interactive environment you can simply run `edgeengine auth`. The CLI will prompt you for required details.
 
 ### Authenticating in a **non**-interactive environment (e.g. in a CI/CD pipeline)
+
 Are you integrating the CLI with a non-interactive environment? Then provide the client ID and the client secret as flags of the command. For example:
 
 `edgeengine auth --client_id example-client-id --client_secret example-client-secret --force`
@@ -43,11 +50,13 @@ Are you integrating the CLI with a non-interactive environment? Then provide the
 Use the `--force` (or `-f`) flag so that the credentials file is always overwritten, even if it already exists.
 
 ## Configure project
+
 The EdgeEngine CLI works with a per-project (or per-directory) based configuration. Each project should have its own configuration file defining the scripts that apply to that project. You might use it to order scripts by website, category (such as firewalls), or otherwise.
 
 Start by including a `edgeengine.json`-file in your project directory. The required contents can be found below 👇.
 
 ### edgeengine.json configuration file
+
 When deploying (`edgeengine deploy`), the CLI tries to find the `edgeengine.json` configuration file in the directory you're running the command from. Through this file you can configure which scripts you'd like to deploy to which site.
 
 Here's an example:
@@ -64,7 +73,7 @@ Here's an example:
       ],
       "file": "edgeengine_scripts/ip-firewall.js",
       // The ID is generated on first deploy, or - optionally - you can configure it yourself.
-      "id": "dcdf7824-b6bd-42b8-9b16-9235eefd583d" 
+      "id": "dcdf7824-b6bd-42b8-9b16-9235eefd583d"
     },
     {
       "name": "Script to show a deploy to a different site",
@@ -73,6 +82,15 @@ Here's an example:
       ],
       "file": "edgeengine_scripts/demo.js",
       "site_id": "15ece821-9eed-4590-9577-b83beda947f7"
+    },
+    {
+      "name": "Script to show a deploy to a different site and stack",
+      "paths": [
+        "demo/*"
+      ],
+      "file": "edgeengine_scripts/demo.js",
+      "site_id": "15ece821-9eed-4590-9577-b83beda947f7",
+      "site_id": "7be2de57-d6d9-4c27-8361-aef01e1870f0"
     }
   ]
 }
@@ -81,30 +99,36 @@ Here's an example:
 > Note that you can define the `site_id` either in a global scope or in a per-script scope. This allows you to deploy to different sites from a single configuration file.
 
 ### Overview of all configuration parameters
-| Key                | Description | 
-| ------------------ | ------ |
-| `stack_id`         | The ID of the stack where your site is in. |
-| `site_id`          | The ID of the site you'd like to apply the scripts to. |
-| `scripts[name]`    | The name of the script. Should be descriptive and unique to each site. |
+
+| Key                | Description                                                                                                                                                                         |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `stack_id`         | The ID of the stack where your site is in.                                                                                                                                          |
+| `site_id`          | The ID of the site you'd like to apply the scripts to.                                                                                                                              |
+| `scripts[name]`    | The name of the script. Should be descriptive and unique to each site.                                                                                                              |
 | `scripts[paths][]` | The paths the script should apply to. Relative to your site. **Without starting `/`**. If you'd like to apply the script to `http://site.com/admin/*` you'd use the `admin/*` path. |
-| `scripts[file]`    | The file where the required JS is in. Define the path relative to the EdgeEngine configuration JSON. Without a starting `/`. |
-| `scripts[id]`      | The ID of the script in the EdgeEngine. Will be created after first deploy. Should be checked into version control after being created. |
+| `scripts[file]`    | The file where the required JS is in. Define the path relative to the EdgeEngine configuration JSON. Without a starting `/`.                                                        |
+| `scripts[id]`      | The ID of the script in the EdgeEngine. Will be created after first deploy. Should be checked into version control after being created.                                             |
 
 ### Where to find the stack and site ID?
+
 You can find the stack and site ID in the URL when you're logged into the StackPath client portal and have selected the CDN site you'd like to deploy scripts to. See the illustration below for more information on which IDs to copy.
 
 ![How to find the IDs in the URL](https://cdn.developer.stackpath.com/assets/github.com/stackpath/edgeengine-cli/README.md/finding-stack-and-site-id.png)
 
 ## Deploying with the CLI
+
 When talking about deploying in the context of the EdgeEngine we mean getting local code onto the StackPath Edge. You might also call it "updating" or "pushing" code.
 
 > 👉 Deploying is as easy as running `edgeengine deploy` from your project directory (given it has the `edgeengine.json`-file).
 
 ### Deploying from a non-interactive environment
+
 During the deployment the CLI might prompt you in certain situations. For example, when your `edgeengine.json` holds an ID that can not be found in the EdgeEngine. The CLI will then prompt you if you'd like to re-create the script. In non-interactive environments you can use the `--force` or `-f` flag to always try to re-create the script.
 
 # Usage
+
 <!-- usage -->
+
 ```sh-session
 $ npm install -g @stackpath/edgeengine-cli
 $ edgeengine COMMAND
@@ -116,15 +140,19 @@ USAGE
   $ edgeengine COMMAND
 ...
 ```
+
 <!-- usagestop -->
 
 # Commands
+
 <!-- commands -->
-* [`edgeengine auth`](#edgeengine-auth)
-* [`edgeengine deploy`](#edgeengine-deploy)
-* [`edgeengine help [COMMAND]`](#edgeengine-help-command)
+
+- [`edgeengine auth`](#edgeengine-auth)
+- [`edgeengine deploy`](#edgeengine-deploy)
+- [`edgeengine help [COMMAND]`](#edgeengine-help-command)
 
 ## `edgeengine auth`
+
 Configures StackPath's authentication details.
 
 ```
@@ -179,7 +207,9 @@ OPTIONS
 ```
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.1.4/src/commands/help.ts)_
+
 <!-- commandsstop -->
 
 # Contributing
+
 We welcome contributions and pull requests to this plugin. See our [contributing guide](https://github.com/stackpath/edgeengine-cli/blob/master/.github/contributing.md) for more information.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Here's an example:
       ],
       "file": "edgeengine_scripts/demo.js",
       "site_id": "15ece821-9eed-4590-9577-b83beda947f7",
-      "site_id": "7be2de57-d6d9-4c27-8361-aef01e1870f0"
+      "stack_id": "7be2de57-d6d9-4c27-8361-aef01e1870f0"
     }
   ]
 }

--- a/src/api/interfaces/configuration-script.ts
+++ b/src/api/interfaces/configuration-script.ts
@@ -4,4 +4,5 @@ export interface IConfigurationScript {
   paths: string[];
   file: string;
   site_id?: string;
+  stack_id?: string;
 }

--- a/src/api/services/deploy.ts
+++ b/src/api/services/deploy.ts
@@ -99,7 +99,7 @@ export class Deploy {
     };
 
     const siteId = script.site_id || this.configuration.site_id;
-    const stackId = this.configuration.stack_id;
+    const stackId = script.stack_id || this.configuration.stack_id;
     const scriptId = script.id;
 
     if (scriptId) {


### PR DESCRIPTION
Fixes #9

Changes proposed in this pull request:
* Define an optional `stack_id` per script in the config file, and use it instead of the global `stack_id` when present.
* Automated formatting changes to `README.md`.